### PR TITLE
Workaround crash in iOS 8

### DIFF
--- a/src/ios/ALRecheckScreenOrientation.m
+++ b/src/ios/ALRecheckScreenOrientation.m
@@ -6,7 +6,12 @@
 - (void)recheckScreenOrientation:(CDVInvokedUrlCommand*)command
 {
     // HACK: Force rotate by changing the view hierarchy. Present modal view then dismiss it immediately.
-    [self.viewController presentViewController:[UIViewController new] animated:NO completion:^{ [self.viewController dismissViewControllerAnimated:NO completion:nil]; }];
+    [self.viewController presentViewController:[UIViewController new] animated:NO completion:^{
+        // delaying dismissal is necessary on iOS 8, crashes otherwise
+        dispatch_after(0, dispatch_get_main_queue(), ^{
+            [self.viewController dismissViewControllerAnimated:NO completion:nil];
+        });
+    }];
 
     // Assume everything went ok
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
Without the workaround, the app crashes with the following error messages:
- Trying to dismiss the presentation controller while transitioning already.
- transitionViewForCurrentTransition is not set, presentation controller was dismissed during the presentation?
